### PR TITLE
Only run dep review on public repos

### DIFF
--- a/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
+++ b/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
@@ -115,7 +115,7 @@ jobs:
         uses: qualcomm/commit-emails-check-action@v1.0.0
 
   dependency-review:
-    if: ${{ inputs.dependency-review }}
+    if: ${{ inputs.dependency-review && !github.event.repository.private }}
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'


### PR DESCRIPTION
We only enable GitHub security on public repos, so we should avoid running this for internal repos as it will always fail otherwise.