### PR TITLE
Run upload sarif step in semgrep if repo is public

### DIFF
--- a/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
+++ b/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
@@ -73,7 +73,7 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        if: ${{ github.event.repository.public }}
+        if: ${{ github.event.repository.visibility == 'public' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep-report.sarif


### PR DESCRIPTION
## Summary
This PR updates the existing SARIF upload step to conditionally run only for **public repositories**.
Previously, the upload step was executed unconditionally, which led to permission-related errors when the repository was internal. This change ensures smoother CI runs by avoiding unnecessary failures in non-public environments.

**Error**:
`Warning: Caught an exception while gathering information for telemetry: HttpError: Resource not accessible by integration - https://docs.github.com/rest/actions/workflow-runs#get-a-workflow-run. Will skip sending status report.`