### PR TITLE
Refactor reusable workflow to compute base_ref and head_ref internally

### DIFF
--- a/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
+++ b/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
@@ -21,13 +21,7 @@ on:
       dependency-review:
         required: false
         type: boolean
-        default: true 
-      base_ref:
-        required: false
-        type: string
-      head_ref:
-        required: false
-        type: string   
+        default: true  
     secrets:
       SEMGREP_APP_TOKEN:
         required: true
@@ -116,14 +110,24 @@ jobs:
         uses: qualcomm/commit-emails-check-action@v1.0.0
 
   dependency-review:
-    if: ${{ inputs.dependency-review && github.event.repository.visibility == 'public' }}
+    if: ${{ inputs.dependency-review && github.event.repository.visibility == 'public' && (github.event_name == 'push' || github.event_name == 'pull_request_target') }}
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
+      - name: Set base ref and head ref
+        id: setrefs
+        run: |
+          if [ "${{github.event_name}}" == "push" ]; then
+            echo "base_ref=${{ github.event.before }}" >> $GITHUB_OUTPUT
+            echo "head_ref=${{ github.sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            echo "base_ref=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "head_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          fi
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
-          base-ref: ${{ inputs.base_ref }}
-          head-ref: ${{ inputs.head_ref }}
+          base-ref: ${{ steps.setrefs.outputs.base_ref }}
+          head-ref: ${{ steps.setrefs.outputs.head_ref }}
           fail-on-severity: high  


### PR DESCRIPTION
## Summary
- Remove the need for `base_ref` and `head_ref` inputs from the calling workflow
- Compute `base_ref` and `head_ref` dynamically inside the reusable workflow based on the event type ( `push` or `pull_request_target`)  


## Tested on qualcomm-linux-stg/qcom-linux-testkit repo
1. Updated Preflight workflow for repo **qcom-linux-testkit** https://github.com/qualcomm-linux-stg/qcom-linux-testkit/blob/main/.github/workflows/preflight-checker-workflow.yml#L15
2. On **push** event Dependency Review job was successful https://github.com/qualcomm-linux-stg/qcom-linux-testkit/actions/runs/15982030801
3. On **Pull_request_target** event Dependency Review job successful https://github.com/qualcomm-linux-stg/qcom-linux-testkit/actions/runs/15982072911