### PR TITLE
proposal to run status checks on the pr branch instead of base branch

### DIFF
--- a/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
+++ b/.github/workflows/qcom-preflight-checks-reusable-workflow.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3


### PR DESCRIPTION
Hi team,

It looks like the status checks on the pull requests fail at the moment because the pipeline tries to execute with the main branch checked out. Typically, if a developer is merging code, the pr pipeline status should reflect the status of the code about to be merged.

**Proposal**:
Please review if we can enable status checks on the branch proposing the changes in the pull request. Reporting status checks of the base branch in the pull request may be misleading and can lead to pipeline failures post merge.

Regards,
Biswajit Roy