### PR TITLE
fix: copyright license checker failing for private repos

### DIFF
--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -33,9 +33,12 @@ jobs:
           echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate patch between base and head
+      - name: Generate patch for PR changes only (merge-base to head).
         run: |
-          git diff "${{ steps.shas.outputs.base_sha }}" \
+          MERGE_BASE=$(git merge-base "${{ steps.shas.outputs.base_sha }}" \
+                                      "${{ steps.shas.outputs.head_sha }}")
+          echo "Merge base: ${MERGE_BASE}"
+          git diff "${MERGE_BASE}" \
                    "${{ steps.shas.outputs.head_sha }}" \
                    > pr.patch
           head -n 100 pr.patch

--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          fetch-depth: 0   # Full history so we can diff properly.
-                                  # On pull_request events, actions/checkout fetches
-                                  # refs/pull/N/merge whose parents are base.sha and
-                                  # head.sha — both are already present after this step.
+          fetch-depth: 0    # Full history so we can diff properly.
+                            # On pull_request events, actions/checkout fetches
+                            # refs/pull/N/merge whose parents are base.sha and
+                            # head.sha — both are already present after this step.
          
  
       - name: Get base and head SHAs (from event payload, no token needed)

--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
           fetch-depth: 0    # Full history so we can diff properly.
                             # On pull_request events, actions/checkout fetches
                             # refs/pull/N/merge whose parents are base.sha and
@@ -24,23 +23,19 @@ jobs:
       - name: Get base and head SHAs (from event payload, no token needed)
         id: shas
         run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          
-          echo "Base SHA: ${BASE_SHA}"
-          echo "Head SHA: ${HEAD_SHA}"
-          
-          echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          git fetch --no-tags --prune origin \
+            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
 
-      - name: Generate patch for PR changes only (merge-base to head).
+      - name: Generate patch for PR changes only (GitHub PR-style 3-dot diff)
         run: |
-          MERGE_BASE=$(git merge-base "${{ steps.shas.outputs.base_sha }}" \
-                                      "${{ steps.shas.outputs.head_sha }}")
-          echo "Merge base: ${MERGE_BASE}"
-          git diff "${MERGE_BASE}" \
-                   "${{ steps.shas.outputs.head_sha }}" \
-                   > pr.patch
+          BASE="origin/${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          # GitHub PRs show a three-dot diff: merge-base(base, head) -> head.
+          # Using the live base branch tip (not the stale SHA from the event
+          # payload) ensures the patch always matches the GitHub PR UI diff.
+
+          git diff "${BASE}...${HEAD}" > pr.patch
           head -n 100 pr.patch
 
       - name: Run Copyright License Check Action

--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -15,18 +15,29 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          fetch-depth: 0  # Full history so we can diff properly
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0   # Full history so we can diff properly.
+                                  # On pull_request events, actions/checkout fetches
+                                  # refs/pull/N/merge whose parents are base.sha and
+                                  # head.sha — both are already present after this step.
+         
  
-      - name: Add PR base repo as remote and fetch it
+      - name: Get base and head SHAs (from event payload, no token needed)
+        id: shas
         run: |
-          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
-          git fetch upstream
- 
-      - name: Generate final patch between base and head
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          
+          echo "Base SHA: ${BASE_SHA}"
+          echo "Head SHA: ${HEAD_SHA}"
+          
+          echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate patch between base and head
         run: |
-          git diff upstream/${{ github.event.pull_request.base.ref }} > pr.patch
+          git diff "${{ steps.shas.outputs.base_sha }}" \
+                   "${{ steps.shas.outputs.head_sha }}" \
+                   > pr.patch
           head -n 100 pr.patch
 
       - name: Run Copyright License Check Action


### PR DESCRIPTION
## Summary

- Refactor reusable-copyright-license-check.yml to use explicit base/head SHAs from the PR event payload instead of fetching a remote upstream branch. This removes the dependency of upstream remote fetch could fail for private Forked Repo.
