### PR TITLE
Add checkout repo step

### DIFF
--- a/.github/workflows/reusable-commit-msg-check.yml
+++ b/.github/workflows/reusable-commit-msg-check.yml
@@ -17,8 +17,13 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Run Commit Message Check Action
         uses: qualcomm/commit-msg-check-action@v2.0.0
         with:
-              base: ${{ github.event.pull_request.base.sha }}
-              head: ${{ github.event.pull_request.head.sha }}
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/reusable-commit-msg-check.yml
+++ b/.github/workflows/reusable-commit-msg-check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Commit Message Check Action
-        uses: qualcomm/commit-msg-check-action@v1.0.0
-        with: ${{ fromJSON(inputs.extra-options || '{}') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: qualcomm/commit-msg-check-action@v2.0.0
+        with:
+              base: ${{ github.event.pull_request.base.sha }}
+              head: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/reusable-commit-msg-check.yml
+++ b/.github/workflows/reusable-commit-msg-check.yml
@@ -23,7 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Run Commit Message Check Action
-        uses: qualcomm/commit-msg-check-action@v2.0.0
+        uses: qualcomm/commit-msg-check-action@v2
         with:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This change is required to support the deprecation of the GitHub API usage in the commit‑msg‑check action. Instead of querying commits via the API, the action will now use the base and head commit SHAs to determine the commit range.