### PR TITLE
fix: merge extra-options with fixed base/head PR SHAs

### DIFF
--- a/.github/workflows/reusable-commit-msg-check.yml
+++ b/.github/workflows/reusable-commit-msg-check.yml
@@ -5,7 +5,7 @@ on:
       extra-options:
         required: false
         type: string
-        default: ''
+        default: '{}'
         description: 'Extra options as YAML/JSON object string'
 
 permissions:
@@ -22,8 +22,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      - name: Prepare action options
+        id: prepare-options
+        env:
+          EXTRA_OPTIONS: ${{ inputs.extra-options }}
+        run: |
+          FIXED='{"base":"${{ github.event.pull_request.base.sha }}","head":"${{ github.event.pull_request.head.sha }}"}'
+          MERGED=$(printf '%s\n%s' "$EXTRA_OPTIONS" "$FIXED" | jq -sc '.[0] * .[1]')
+          echo "options=$MERGED" >> "$GITHUB_OUTPUT"
       - name: Run Commit Message Check Action
         uses: qualcomm/commit-msg-check-action@v2
-        with:
-          base: ${{ github.event.pull_request.base.sha }}
-          head: ${{ github.event.pull_request.head.sha }}
+        with: ${{ fromJSON(steps.prepare-options.outputs.options) }}

--- a/.github/workflows/reusable-commit-msg-check.yml
+++ b/.github/workflows/reusable-commit-msg-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Prepare action options
         id: prepare-options
         env:
-          EXTRA_OPTIONS: ${{ inputs.extra-options }}
+          EXTRA_OPTIONS: ${{ inputs.extra-options || '{}' }}
         run: |
           FIXED='{"base":"${{ github.event.pull_request.base.sha }}","head":"${{ github.event.pull_request.head.sha }}"}'
           MERGED=$(printf '%s\n%s' "$EXTRA_OPTIONS" "$FIXED" | jq -sc '.[0] * .[1]')

--- a/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml
+++ b/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml
@@ -34,7 +34,7 @@ on:
       commit-msg-check-extra-options:
         required: false
         type: string
-        default: ''
+        default: '{}'
         description: 'Extra options as YAML/JSON object string, e.g., {"body-char-limit": 60, "sub-char-limit": 50, "check-blank-line": true}'
       enable-armor-checkers:
         required: false

--- a/.github/workflows/test-preflight.yml
+++ b/.github/workflows/test-preflight.yml
@@ -18,8 +18,8 @@ jobs:
       enable-repolinter-check: true
       enable-copyright-license-check: true
       enable-commit-email-check: true
-      enable-commit-msg-check: false # change to true to see some commit message check failures
-      commit-msg-check-extra-options: '{"check-blank-line": false}'
+      enable-commit-msg-check: true # change to true to see some commit message check failures
+      commit-msg-check-extra-options: '{"check-blank-line": true, "body-char-limit": 70, "sub-char-limit": 70}'
       enable-armor-checkers: false # change to true to run API/ABI backward compatibility checks
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Add a prepare step that merges caller-supplied extra-options JSON with  the fixed base and head values derived from the pull_request event.
Use jq -sc to produce compact single-line output required by GITHUB_OUTPUT, and pass extra-options via env to prevent shell injection.