### PR TITLE
Update copyright-license-checker-action to v1.2.1

### DIFF
--- a/.github/workflows/reusable-copyright-license-check.yml
+++ b/.github/workflows/reusable-copyright-license-check.yml
@@ -39,7 +39,7 @@ jobs:
           head -n 100 pr.patch
 
       - name: Run Copyright License Check Action
-        uses: qualcomm/copyright-license-checker-action@v1.2.0
+        uses: qualcomm/copyright-license-checker-action@f2293b77d340fe6df98bc2113a7cfe37d5cd32ca
         with:
           patch_file: pr.patch
           repo_name: ${{ github.repository }}


### PR DESCRIPTION
https://jira-dc.qualcomm.com/jira/browse/LOSTINTPRJ-2090
https://github.com/qualcomm/copyright-license-checker-action/releases/tag/v1.2.1

## PR Summary

### Overview

Enhanced the license detection system to support multiple LICENSE file naming conventions and added support for Apache-2.0 with LLVM exceptions.

### Key Changes

__1. Case-Insensitive LICENSE File Detection__

- Extended `license_file_candidates` list to include uppercase and mixed-case variations
- Now supports: `LICENSE.TXT`, `LICENSE.MD`, `COPYING.txt`, `COPYING.TXT`, `License`, `License.txt`, `License.md`
- Resolves issues where repositories using uppercase LICENSE file names (e.g., `LICENSE.TXT`) were not being detected

__2. Apache-2.0 WITH LLVM-exception Support__

- Added `Apache-2.0 WITH LLVM-exception` to the `PERMISSIVE_LICENSES` list
- Added full SPDX expression: `Apache-2.0 WITH LLVM-exception AND Apache-2.0 AND LLVM-exception`
- Enables proper detection and acceptance of LLVM Project licenses

### Impact

- __Improved Compatibility__: Action now works with repositories using various LICENSE file naming conventions
- __LLVM Project Support__: Properly recognizes and accepts Apache-2.0 with LLVM exceptions as a permissive license
- __No Breaking Changes__: Existing functionality remains intact; only adds new supported formats

### Testing
https://github.com/targoy-qti/cpullvm-toolchain/actions/runs/29677212725

