### PR TITLE
feat: add repo-policy-action as a non-blocking shadow check

### DIFF
--- a/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml
+++ b/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml
@@ -14,7 +14,11 @@ on:
       enable-repolinter-check:
         required: false
         type: boolean
-        default: true        
+        default: true
+      enable-repo-policy-check:
+        required: false
+        type: boolean
+        default: true
       enable-copyright-license-check:
         required: false
         type: boolean
@@ -68,6 +72,13 @@ jobs:
     if: ${{ inputs.enable-repolinter-check }}
     name: Repolinter Check
     uses: ./.github/workflows/reusable-repolinter-check.yml
+    permissions:
+      contents: read
+
+  repo-policy-check:
+    if: ${{ inputs.enable-repo-policy-check }}
+    name: Repository Policy Check
+    uses: ./.github/workflows/reusable-repo-policy-check.yml
     permissions:
       contents: read
 

--- a/.github/workflows/reusable-repo-policy-check.yml
+++ b/.github/workflows/reusable-repo-policy-check.yml
@@ -1,0 +1,26 @@
+name: Repository Policy Check Reusable Workflow
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  run-repo-policy-check:
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+    name: Run Repository Policy Check (shadow mode)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Run Repository Policy Check
+        # TODO: qualcomm/repo-policy-action has no released version yet — pinned to
+        # @main per team decision. Update to a proper vX tag once one is cut.
+        # This step is non-blocking (continue-on-error) while its output is
+        # compared against repolinter's before it becomes the enforced gate.
+        continue-on-error: true
+        uses: qualcomm/repo-policy-action@main
+        with:
+          config_url: "https://raw.githubusercontent.com/qualcomm/.github/main/repolint.json"


### PR DESCRIPTION
## Summary
- Adds `qualcomm/repo-policy-action` as its own reusable workflow (`reusable-repo-policy-check.yml`), run as a **non-blocking shadow check** (`continue-on-error: true`) in parallel with the existing `repolinter-check` job.
- Wires it into the orchestrator behind a new `enable-repo-policy-check` input (default `true`), following the same pattern as the other checks.
- `todogroup/repolinter-action` remains the sole blocking gate for now, unchanged.

## Why
`todogroup/repolinter-action`/`repolinter` are archived (Feb 2026) with known CVEs and no commits since 2021. `qualcomm/repo-policy-action` is the intended Python replacement — it parses the same `repolint.json` schema. Running it in shadow mode first lets us compare its output against repolinter's across real repos before promoting it to the enforced gate.

## Notes
- `qualcomm/repo-policy-action` has no released version tag yet, so it's pinned to `@main` with an inline TODO to update once one is cut.
- Opened as a draft since the shadow-mode observation period and the version pin are both still open follow-ups.

## Test plan
- [ ] Confirm `repolinter-check` still gates PRs as before
- [ ] Confirm the new `repo-policy-check` job runs and reports results but never fails the job
- [ ] Compare shadow-check output against repolinter's on a few real repos
- [ ] Pin `qualcomm/repo-policy-action` to a version tag once one exists
